### PR TITLE
fix: Post Login URL integrated

### DIFF
--- a/src/lib/auth/auth.ts
+++ b/src/lib/auth/auth.ts
@@ -11,6 +11,7 @@ import {
   ZITADEL_CLIENT_SECRET,
   ZITADEL_DOMAIN,
   ZITADEL_POST_LOGOUT_URL,
+  ZITADEL_POST_LOGIN_URL
 } from '$env/static/private';
 
 /**
@@ -314,7 +315,10 @@ export const { handle } = SvelteKitAuth({
      * @returns The URL to redirect the user to after successful login
      */
     async redirect({ baseUrl }) {
-      return `${baseUrl}/profile`;
+      if (!ZITADEL_POST_LOGIN_URL) {
+        return `${baseUrl}/profile`;
+      } 
+      return `${baseUrl}${ZITADEL_POST_LOGIN_URL}`;
     },
 
     /**


### PR DESCRIPTION
Fixing post login redirect behaviour

## Description

I integrated the `ZITADEL_POST_LOGIN_URL` to work as expected and described in [`.env.example`](https://github.com/zitadel/example-auth-sveltekit/blob/main/.env.example#L52-L55):
```
# The internal URL within your application where users are sent after a
# successful login is processed at the callback URL.
# Defaults to "/profile" if not specified.
ZITADEL_POST_LOGIN_URL="/profile"
```

## Related Issue

I worked on #18 while stumbling across this little mistake.

## Motivation and Context

Restoring expected / planned behaviour

## How Has This Been Tested?

I manually tested:
- Commenting out the `ZITADEL_POST_LOGIN_URL` in my .env file -> redirects to `/profile` after login
- Setting `/profile` and `/test` as post login url -> redirects to those after login

## Documentation:

None needed

## Checklist:

- [ ] I have updated the documentation accordingly.
- [ ] I have assigned the correct milestone or created one if non-existent.
- [ ] I have correctly labeled this pull request.
- [ ] I have linked the corresponding issue in this description.
- [ ] I have requested a review from at least 2 reviewers
- [x] I have checked the base branch of this pull request
- [x] I have checked my code for any possible security vulnerabilities
